### PR TITLE
Sync to react-native d8e6c4578 (rename NativePrimitive => ReservedProp)

### DIFF
--- a/change/react-native-tscodegen-2020-08-12-14-38-38-bumpvers.json
+++ b/change/react-native-tscodegen-2020-08-12-14-38-38-bumpvers.json
@@ -1,5 +1,5 @@
 {
-  "type": "patch",
+  "type": "minor",
   "comment": "Sync to react-native d8e6c4578 (rename NativePrimitive => ReservedProp)",
   "packageName": "react-native-tscodegen",
   "email": "acoates-ms@noreply.github.com",

--- a/change/react-native-tscodegen-2020-08-12-14-38-38-bumpvers.json
+++ b/change/react-native-tscodegen-2020-08-12-14-38-38-bumpvers.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Sync to react-native d8e6c4578 (rename NativePrimitive => ReservedProp)",
+  "packageName": "react-native-tscodegen",
+  "email": "acoates-ms@noreply.github.com",
+  "commit": "8e39f3cb7cf554ed8d8b85533f196d634990bcc6",
+  "date": "2020-08-12T21:38:38.564Z",
+  "file": "E:\\Repos\\react-native-tscodegen\\change\\react-native-tscodegen-2020-08-12-14-38-38-bumpvers.json"
+}

--- a/packages/RN-TSCodegen-Test/src/inputs/components_success/ALL_PROP_TYPES_NO_EVENTS.json
+++ b/packages/RN-TSCodegen-Test/src/inputs/components_success/ALL_PROP_TYPES_NO_EVENTS.json
@@ -324,7 +324,7 @@
               "optional": false,
               "typeAnnotation": {
                 "name": "ImageSourcePrimitive",
-                "type": "NativePrimitiveTypeAnnotation"
+                "type": "ReservedPropTypeAnnotation"
               }
             },
             {
@@ -332,7 +332,7 @@
               "optional": true,
               "typeAnnotation": {
                 "name": "ImageSourcePrimitive",
-                "type": "NativePrimitiveTypeAnnotation"
+                "type": "ReservedPropTypeAnnotation"
               }
             },
             {
@@ -340,7 +340,7 @@
               "optional": true,
               "typeAnnotation": {
                 "name": "ImageSourcePrimitive",
-                "type": "NativePrimitiveTypeAnnotation"
+                "type": "ReservedPropTypeAnnotation"
               }
             },
             {
@@ -348,7 +348,7 @@
               "optional": false,
               "typeAnnotation": {
                 "name": "ColorPrimitive",
-                "type": "NativePrimitiveTypeAnnotation"
+                "type": "ReservedPropTypeAnnotation"
               }
             },
             {
@@ -356,7 +356,7 @@
               "optional": true,
               "typeAnnotation": {
                 "name": "ColorPrimitive",
-                "type": "NativePrimitiveTypeAnnotation"
+                "type": "ReservedPropTypeAnnotation"
               }
             },
             {
@@ -364,7 +364,7 @@
               "optional": true,
               "typeAnnotation": {
                 "name": "ColorPrimitive",
-                "type": "NativePrimitiveTypeAnnotation"
+                "type": "ReservedPropTypeAnnotation"
               }
             },
             {
@@ -372,7 +372,7 @@
               "optional": true,
               "typeAnnotation": {
                 "name": "ColorPrimitive",
-                "type": "NativePrimitiveTypeAnnotation"
+                "type": "ReservedPropTypeAnnotation"
               }
             },
             {
@@ -381,7 +381,7 @@
               "typeAnnotation": {
                 "elementType": {
                   "name": "ColorPrimitive",
-                  "type": "NativePrimitiveTypeAnnotation"
+                  "type": "ReservedPropTypeAnnotation"
                 },
                 "type": "ArrayTypeAnnotation"
               }
@@ -392,7 +392,7 @@
               "typeAnnotation": {
                 "elementType": {
                   "name": "ColorPrimitive",
-                  "type": "NativePrimitiveTypeAnnotation"
+                  "type": "ReservedPropTypeAnnotation"
                 },
                 "type": "ArrayTypeAnnotation"
               }
@@ -403,7 +403,7 @@
               "typeAnnotation": {
                 "elementType": {
                   "name": "ColorPrimitive",
-                  "type": "NativePrimitiveTypeAnnotation"
+                  "type": "ReservedPropTypeAnnotation"
                 },
                 "type": "ArrayTypeAnnotation"
               }
@@ -414,7 +414,7 @@
               "typeAnnotation": {
                 "elementType": {
                   "name": "ColorPrimitive",
-                  "type": "NativePrimitiveTypeAnnotation"
+                  "type": "ReservedPropTypeAnnotation"
                 },
                 "type": "ArrayTypeAnnotation"
               }
@@ -424,7 +424,7 @@
               "optional": false,
               "typeAnnotation": {
                 "name": "ColorPrimitive",
-                "type": "NativePrimitiveTypeAnnotation"
+                "type": "ReservedPropTypeAnnotation"
               }
             },
             {
@@ -432,7 +432,7 @@
               "optional": true,
               "typeAnnotation": {
                 "name": "ColorPrimitive",
-                "type": "NativePrimitiveTypeAnnotation"
+                "type": "ReservedPropTypeAnnotation"
               }
             },
             {
@@ -440,7 +440,7 @@
               "optional": true,
               "typeAnnotation": {
                 "name": "ColorPrimitive",
-                "type": "NativePrimitiveTypeAnnotation"
+                "type": "ReservedPropTypeAnnotation"
               }
             },
             {
@@ -448,7 +448,7 @@
               "optional": true,
               "typeAnnotation": {
                 "name": "ColorPrimitive",
-                "type": "NativePrimitiveTypeAnnotation"
+                "type": "ReservedPropTypeAnnotation"
               }
             },
             {
@@ -456,7 +456,7 @@
               "optional": false,
               "typeAnnotation": {
                 "name": "PointPrimitive",
-                "type": "NativePrimitiveTypeAnnotation"
+                "type": "ReservedPropTypeAnnotation"
               }
             },
             {
@@ -464,7 +464,7 @@
               "optional": true,
               "typeAnnotation": {
                 "name": "PointPrimitive",
-                "type": "NativePrimitiveTypeAnnotation"
+                "type": "ReservedPropTypeAnnotation"
               }
             },
             {
@@ -472,7 +472,7 @@
               "optional": true,
               "typeAnnotation": {
                 "name": "PointPrimitive",
-                "type": "NativePrimitiveTypeAnnotation"
+                "type": "ReservedPropTypeAnnotation"
               }
             },
             {
@@ -480,7 +480,7 @@
               "optional": true,
               "typeAnnotation": {
                 "name": "PointPrimitive",
-                "type": "NativePrimitiveTypeAnnotation"
+                "type": "ReservedPropTypeAnnotation"
               }
             },
             {
@@ -488,7 +488,7 @@
               "optional": false,
               "typeAnnotation": {
                 "name": "EdgeInsetsPrimitive",
-                "type": "NativePrimitiveTypeAnnotation"
+                "type": "ReservedPropTypeAnnotation"
               }
             },
             {
@@ -496,7 +496,7 @@
               "optional": true,
               "typeAnnotation": {
                 "name": "EdgeInsetsPrimitive",
-                "type": "NativePrimitiveTypeAnnotation"
+                "type": "ReservedPropTypeAnnotation"
               }
             },
             {
@@ -504,7 +504,7 @@
               "optional": true,
               "typeAnnotation": {
                 "name": "EdgeInsetsPrimitive",
-                "type": "NativePrimitiveTypeAnnotation"
+                "type": "ReservedPropTypeAnnotation"
               }
             },
             {
@@ -512,7 +512,7 @@
               "optional": true,
               "typeAnnotation": {
                 "name": "EdgeInsetsPrimitive",
-                "type": "NativePrimitiveTypeAnnotation"
+                "type": "ReservedPropTypeAnnotation"
               }
             }
           ]

--- a/packages/RN-TSCodegen-Test/src/inputs/components_success/ARRAY_PROP_TYPES_NO_EVENTS.json
+++ b/packages/RN-TSCodegen-Test/src/inputs/components_success/ARRAY_PROP_TYPES_NO_EVENTS.json
@@ -256,7 +256,7 @@
               "typeAnnotation": {
                 "elementType": {
                   "name": "ImageSourcePrimitive",
-                  "type": "NativePrimitiveTypeAnnotation"
+                  "type": "ReservedPropTypeAnnotation"
                 },
                 "type": "ArrayTypeAnnotation"
               }
@@ -267,7 +267,7 @@
               "typeAnnotation": {
                 "elementType": {
                   "name": "ImageSourcePrimitive",
-                  "type": "NativePrimitiveTypeAnnotation"
+                  "type": "ReservedPropTypeAnnotation"
                 },
                 "type": "ArrayTypeAnnotation"
               }
@@ -278,7 +278,7 @@
               "typeAnnotation": {
                 "elementType": {
                   "name": "ImageSourcePrimitive",
-                  "type": "NativePrimitiveTypeAnnotation"
+                  "type": "ReservedPropTypeAnnotation"
                 },
                 "type": "ArrayTypeAnnotation"
               }
@@ -289,7 +289,7 @@
               "typeAnnotation": {
                 "elementType": {
                   "name": "ImageSourcePrimitive",
-                  "type": "NativePrimitiveTypeAnnotation"
+                  "type": "ReservedPropTypeAnnotation"
                 },
                 "type": "ArrayTypeAnnotation"
               }
@@ -300,7 +300,7 @@
               "typeAnnotation": {
                 "elementType": {
                   "name": "ColorPrimitive",
-                  "type": "NativePrimitiveTypeAnnotation"
+                  "type": "ReservedPropTypeAnnotation"
                 },
                 "type": "ArrayTypeAnnotation"
               }
@@ -311,7 +311,7 @@
               "typeAnnotation": {
                 "elementType": {
                   "name": "ColorPrimitive",
-                  "type": "NativePrimitiveTypeAnnotation"
+                  "type": "ReservedPropTypeAnnotation"
                 },
                 "type": "ArrayTypeAnnotation"
               }
@@ -322,7 +322,7 @@
               "typeAnnotation": {
                 "elementType": {
                   "name": "ColorPrimitive",
-                  "type": "NativePrimitiveTypeAnnotation"
+                  "type": "ReservedPropTypeAnnotation"
                 },
                 "type": "ArrayTypeAnnotation"
               }
@@ -333,7 +333,7 @@
               "typeAnnotation": {
                 "elementType": {
                   "name": "ColorPrimitive",
-                  "type": "NativePrimitiveTypeAnnotation"
+                  "type": "ReservedPropTypeAnnotation"
                 },
                 "type": "ArrayTypeAnnotation"
               }
@@ -344,7 +344,7 @@
               "typeAnnotation": {
                 "elementType": {
                   "name": "PointPrimitive",
-                  "type": "NativePrimitiveTypeAnnotation"
+                  "type": "ReservedPropTypeAnnotation"
                 },
                 "type": "ArrayTypeAnnotation"
               }
@@ -355,7 +355,7 @@
               "typeAnnotation": {
                 "elementType": {
                   "name": "PointPrimitive",
-                  "type": "NativePrimitiveTypeAnnotation"
+                  "type": "ReservedPropTypeAnnotation"
                 },
                 "type": "ArrayTypeAnnotation"
               }
@@ -366,7 +366,7 @@
               "typeAnnotation": {
                 "elementType": {
                   "name": "PointPrimitive",
-                  "type": "NativePrimitiveTypeAnnotation"
+                  "type": "ReservedPropTypeAnnotation"
                 },
                 "type": "ArrayTypeAnnotation"
               }
@@ -377,7 +377,7 @@
               "typeAnnotation": {
                 "elementType": {
                   "name": "PointPrimitive",
-                  "type": "NativePrimitiveTypeAnnotation"
+                  "type": "ReservedPropTypeAnnotation"
                 },
                 "type": "ArrayTypeAnnotation"
               }
@@ -388,7 +388,7 @@
               "typeAnnotation": {
                 "elementType": {
                   "name": "EdgeInsetsPrimitive",
-                  "type": "NativePrimitiveTypeAnnotation"
+                  "type": "ReservedPropTypeAnnotation"
                 },
                 "type": "ArrayTypeAnnotation"
               }
@@ -399,7 +399,7 @@
               "typeAnnotation": {
                 "elementType": {
                   "name": "EdgeInsetsPrimitive",
-                  "type": "NativePrimitiveTypeAnnotation"
+                  "type": "ReservedPropTypeAnnotation"
                 },
                 "type": "ArrayTypeAnnotation"
               }
@@ -410,7 +410,7 @@
               "typeAnnotation": {
                 "elementType": {
                   "name": "EdgeInsetsPrimitive",
-                  "type": "NativePrimitiveTypeAnnotation"
+                  "type": "ReservedPropTypeAnnotation"
                 },
                 "type": "ArrayTypeAnnotation"
               }
@@ -421,7 +421,7 @@
               "typeAnnotation": {
                 "elementType": {
                   "name": "EdgeInsetsPrimitive",
-                  "type": "NativePrimitiveTypeAnnotation"
+                  "type": "ReservedPropTypeAnnotation"
                 },
                 "type": "ArrayTypeAnnotation"
               }

--- a/packages/RN-TSCodegen-Test/src/inputs/components_success/OBJECT_PROP_TYPES_NO_EVENTS.json
+++ b/packages/RN-TSCodegen-Test/src/inputs/components_success/OBJECT_PROP_TYPES_NO_EVENTS.json
@@ -220,7 +220,7 @@
                     "optional": false,
                     "typeAnnotation": {
                       "name": "ImageSourcePrimitive",
-                      "type": "NativePrimitiveTypeAnnotation"
+                      "type": "ReservedPropTypeAnnotation"
                     }
                   }
                 ],
@@ -237,7 +237,7 @@
                     "optional": true,
                     "typeAnnotation": {
                       "name": "ImageSourcePrimitive",
-                      "type": "NativePrimitiveTypeAnnotation"
+                      "type": "ReservedPropTypeAnnotation"
                     }
                   }
                 ],
@@ -254,7 +254,7 @@
                     "optional": true,
                     "typeAnnotation": {
                       "name": "ImageSourcePrimitive",
-                      "type": "NativePrimitiveTypeAnnotation"
+                      "type": "ReservedPropTypeAnnotation"
                     }
                   }
                 ],
@@ -271,7 +271,7 @@
                     "optional": true,
                     "typeAnnotation": {
                       "name": "ImageSourcePrimitive",
-                      "type": "NativePrimitiveTypeAnnotation"
+                      "type": "ReservedPropTypeAnnotation"
                     }
                   }
                 ],
@@ -288,7 +288,7 @@
                     "optional": false,
                     "typeAnnotation": {
                       "name": "ColorPrimitive",
-                      "type": "NativePrimitiveTypeAnnotation"
+                      "type": "ReservedPropTypeAnnotation"
                     }
                   }
                 ],
@@ -305,7 +305,7 @@
                     "optional": true,
                     "typeAnnotation": {
                       "name": "ColorPrimitive",
-                      "type": "NativePrimitiveTypeAnnotation"
+                      "type": "ReservedPropTypeAnnotation"
                     }
                   }
                 ],
@@ -322,7 +322,7 @@
                     "optional": true,
                     "typeAnnotation": {
                       "name": "ColorPrimitive",
-                      "type": "NativePrimitiveTypeAnnotation"
+                      "type": "ReservedPropTypeAnnotation"
                     }
                   }
                 ],
@@ -339,7 +339,7 @@
                     "optional": true,
                     "typeAnnotation": {
                       "name": "ColorPrimitive",
-                      "type": "NativePrimitiveTypeAnnotation"
+                      "type": "ReservedPropTypeAnnotation"
                     }
                   }
                 ],
@@ -356,7 +356,7 @@
                     "optional": false,
                     "typeAnnotation": {
                       "name": "ColorPrimitive",
-                      "type": "NativePrimitiveTypeAnnotation"
+                      "type": "ReservedPropTypeAnnotation"
                     }
                   }
                 ],
@@ -373,7 +373,7 @@
                     "optional": true,
                     "typeAnnotation": {
                       "name": "ColorPrimitive",
-                      "type": "NativePrimitiveTypeAnnotation"
+                      "type": "ReservedPropTypeAnnotation"
                     }
                   }
                 ],
@@ -390,7 +390,7 @@
                     "optional": true,
                     "typeAnnotation": {
                       "name": "ColorPrimitive",
-                      "type": "NativePrimitiveTypeAnnotation"
+                      "type": "ReservedPropTypeAnnotation"
                     }
                   }
                 ],
@@ -407,7 +407,7 @@
                     "optional": true,
                     "typeAnnotation": {
                       "name": "ColorPrimitive",
-                      "type": "NativePrimitiveTypeAnnotation"
+                      "type": "ReservedPropTypeAnnotation"
                     }
                   }
                 ],
@@ -424,7 +424,7 @@
                     "optional": false,
                     "typeAnnotation": {
                       "name": "PointPrimitive",
-                      "type": "NativePrimitiveTypeAnnotation"
+                      "type": "ReservedPropTypeAnnotation"
                     }
                   }
                 ],
@@ -441,7 +441,7 @@
                     "optional": true,
                     "typeAnnotation": {
                       "name": "PointPrimitive",
-                      "type": "NativePrimitiveTypeAnnotation"
+                      "type": "ReservedPropTypeAnnotation"
                     }
                   }
                 ],
@@ -458,7 +458,7 @@
                     "optional": true,
                     "typeAnnotation": {
                       "name": "PointPrimitive",
-                      "type": "NativePrimitiveTypeAnnotation"
+                      "type": "ReservedPropTypeAnnotation"
                     }
                   }
                 ],
@@ -475,7 +475,7 @@
                     "optional": true,
                     "typeAnnotation": {
                       "name": "PointPrimitive",
-                      "type": "NativePrimitiveTypeAnnotation"
+                      "type": "ReservedPropTypeAnnotation"
                     }
                   }
                 ],
@@ -492,7 +492,7 @@
                     "optional": false,
                     "typeAnnotation": {
                       "name": "EdgeInsetsPrimitive",
-                      "type": "NativePrimitiveTypeAnnotation"
+                      "type": "ReservedPropTypeAnnotation"
                     }
                   }
                 ],
@@ -509,7 +509,7 @@
                     "optional": true,
                     "typeAnnotation": {
                       "name": "EdgeInsetsPrimitive",
-                      "type": "NativePrimitiveTypeAnnotation"
+                      "type": "ReservedPropTypeAnnotation"
                     }
                   }
                 ],
@@ -526,7 +526,7 @@
                     "optional": true,
                     "typeAnnotation": {
                       "name": "EdgeInsetsPrimitive",
-                      "type": "NativePrimitiveTypeAnnotation"
+                      "type": "ReservedPropTypeAnnotation"
                     }
                   }
                 ],
@@ -543,7 +543,7 @@
                     "optional": true,
                     "typeAnnotation": {
                       "name": "EdgeInsetsPrimitive",
-                      "type": "NativePrimitiveTypeAnnotation"
+                      "type": "ReservedPropTypeAnnotation"
                     }
                   }
                 ],

--- a/packages/RN-TSCodegen/src/CodegenSchema.ts
+++ b/packages/RN-TSCodegen/src/CodegenSchema.ts
@@ -125,7 +125,7 @@ export type PropTypeTypeAnnotation =
       }>;
     }>
   | Readonly<{
-      type: 'NativePrimitiveTypeAnnotation';
+      type: 'ReservedPropTypeAnnotation';
       name:
         | 'ColorPrimitive'
         | 'ImageSourcePrimitive'
@@ -166,7 +166,7 @@ export type PropTypeTypeAnnotation =
             properties: ReadonlyArray<PropTypeShape>;
           }>
         | Readonly<{
-            type: 'NativePrimitiveTypeAnnotation';
+            type: 'ReservedPropTypeAnnotation';
             name:
               | 'ColorPrimitive'
               | 'ImageSourcePrimitive'

--- a/packages/RN-TSCodegen/src/ComponentPropertyParser.ts
+++ b/packages/RN-TSCodegen/src/ComponentPropertyParser.ts
@@ -61,19 +61,19 @@ function rnRawTypeToPropTypeTypeAnnotation(rawType: RNRawType, typeNode: ts.Type
       default: (rawType.defaultValue === undefined ? rawType.values[0] : +rawType.defaultValue)
     }];
     case 'rn:ColorPrimitive': return [rawType.isNullable, {
-      type: 'NativePrimitiveTypeAnnotation',
+      type: 'ReservedPropTypeAnnotation',
       name: 'ColorPrimitive'
     }];
     case 'rn:ImageSourcePrimitive': return [rawType.isNullable, {
-      type: 'NativePrimitiveTypeAnnotation',
+      type: 'ReservedPropTypeAnnotation',
       name: 'ImageSourcePrimitive'
     }];
     case 'rn:PointPrimitive': return [rawType.isNullable, {
-      type: 'NativePrimitiveTypeAnnotation',
+      type: 'ReservedPropTypeAnnotation',
       name: 'PointPrimitive'
     }];
     case 'rn:EdgeInsetsPrimitive': return [rawType.isNullable, {
-      type: 'NativePrimitiveTypeAnnotation',
+      type: 'ReservedPropTypeAnnotation',
       name: 'EdgeInsetsPrimitive'
     }];
     case 'Object': return [rawType.isNullable, rnRawTypeToObjectTypeAnnotation(rawType, typeNode)];
@@ -110,28 +110,28 @@ function rnRawTypeToPropTypeTypeAnnotation(rawType: RNRawType, typeNode: ts.Type
         case 'rn:ColorPrimitive': return [rawType.isNullable, {
           type: 'ArrayTypeAnnotation',
           elementType: {
-            type: 'NativePrimitiveTypeAnnotation',
+            type: 'ReservedPropTypeAnnotation',
             name: 'ColorPrimitive'
           }
         }];
         case 'rn:ImageSourcePrimitive': return [rawType.isNullable, {
           type: 'ArrayTypeAnnotation',
           elementType: {
-            type: 'NativePrimitiveTypeAnnotation',
+            type: 'ReservedPropTypeAnnotation',
             name: 'ImageSourcePrimitive'
           }
         }];
         case 'rn:PointPrimitive': return [rawType.isNullable, {
           type: 'ArrayTypeAnnotation',
           elementType: {
-            type: 'NativePrimitiveTypeAnnotation',
+            type: 'ReservedPropTypeAnnotation',
             name: 'PointPrimitive'
           }
         }];
         case 'rn:EdgeInsetsPrimitive': return [rawType.isNullable, {
           type: 'ArrayTypeAnnotation',
           elementType: {
-            type: 'NativePrimitiveTypeAnnotation',
+            type: 'ReservedPropTypeAnnotation',
             name: 'EdgeInsetsPrimitive'
           }
         }];


### PR DESCRIPTION
Update to react-native 0.0.0-d8e6c4578.

Required for https://github.com/microsoft/react-native-windows/pull/5702

Specifically this brings in changes from: https://github.com/facebook/react-native/commit/1b2bcb180c87a02630f0c346ac88be5acfb552ef#diff-12d2c140f04c4bfafc178b6664c55fdd